### PR TITLE
Feature/fill refsetdb

### DIFF
--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -181,10 +181,14 @@ def add_database_bam(bam_files, sample_refset, conflicts):
         sample_id = get_sample_id(bam)
         flowcell_id = get_flowcell_id_bam(bam)
         refset = list(sample_refset[sample_id].keys())[0]
-        if "WARNING" in "".join(sample_refset[sample_id][refset]):
+        joined_warning = "".join(sample_refset[sample_id][refset])
+        if "WARNING" in joined_warning:
             refset_db = parse_refset(flowcell_id, sample_id)
             if not refset_db:
-                conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, bam]
+                if "DO_NOT_USE_MergeSample" in joined_warning:  # Other warning used correct refset in reanalysis
+                    conflicts["warning"][sample_id] = [flowcell_id, "not_in_db", refset, bam]
+                else:
+                    refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
         else:
             refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
             if not added:

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -128,163 +128,67 @@ def get_sample_id(bam):
         sampleid = "_".join(sampleid)
     return sampleid
 
+def get_folder_sorted(path):
+    folders = sorted(set(glob.glob("{}*".format(path), recursive=True)))
+    return folders
 
-def get_qc_bam_files(path):
-    folders = set(glob.glob("{}*".format(path), recursive=True))
-    print("Number of folders detected = {}".format(len(folders)))
+
+def get_qc_bam_files(folder):
     bam_files = []
-    qc_files = {}
-    for folder in folders:
-        qc_file = glob.glob("{}/QC/CNV/*exomedepth_summary.txt".format(folder), recursive=True)
-        if not qc_file:
-            print("WARNING: CNV QC file missing folder {} Skipping all samples in folder!".format(folder))
-            continue
+    qc_file = glob.glob("{}/QC/CNV/*exomedepth_summary.txt".format(folder), recursive=True)
+    if not qc_file or len(qc_file) > 1:
+        print("WARNING: CNV QC file missing of multiple detected in folder {} Skipping all samples in folder!".format(folder))
+        return None, None, True
 
-        if len(qc_file) > 1:
-            print("WARNING: Multiple QC files detected in folder {} Skipping all samples in folder!".format(folder))
-            continue
+    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder), recursive=True): #  Nextflow analysis
+        bam_files.append(nf_bam)
 
-        if folder not in qc_files:
-            qc_files[folder] = qc_file[0]
-        else:
-            "WARNING: folder {} has been detected multiple times. Skipping all samples in folder!".format(folder)
+    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder), recursive=True): # IAP analysis
+        bam_files.append(iap_bam)
 
-        for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder), recursive=True): #  Nextflow analysis
-            bam_files.append(nf_bam)
+    return qc_file[0], bam_files, False
 
-        for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder), recursive=True): # IAP analysis
-            bam_files.append(iap_bam)
 
-    print("Number of folders with qc_file detected = {}".format(len(qc_files)))
-    print("Number of BAM files detected = {}".format(len(bam_files)))
-
-    return qc_files, bam_files
- 
-
-def parse_refset_qc_files(qc_files):
+def parse_refset_qc_file(qc_file):
     sample_refset = {}
-    for qc_file in qc_files:
-        print(qc_files[qc_file])
-        with open(qc_files[qc_file], 'r') as refset_qc:
-            for line in refset_qc.readlines():
-                if "REFSET" in line:
-                    splitline = line.rstrip().split(";")
+    with open(qc_file, 'r') as refset_qc:
+        for line in refset_qc.readlines():
+            if "REFSET" in line:
+                splitline = line.rstrip().split(";")
+                sample_id = splitline[0]
+                warning = ""
+                header = []
+                for item in splitline:
+                    header.append(item.split("=")[0])
+                refset_index = header.index('REFSET')
+                refset_sample = splitline[refset_index].replace("REFSET=", "")
 
-                    #  Determine index position of "REFSET="
-                    header = []
-                    for item in splitline:
-                        header.append(item.split("=")[0])
-                    refset_index = header.index('REFSET')
+                if "WARNING" in line:
+                    warning = ",".join(line.rstrip().split("\t")[1:])
 
-                    #  Parse used reference set from QC file into dictionary
-                    refset_sample = splitline[refset_index].replace("REFSET=", "")
-                    sample_id = splitline[0] 
-
-                    warning = "none"
-                    if "WARNING" in line:
-                        warning = ",".join(line.rstrip().split("\t")[1:])
-
-                    if sample_id not in sample_refset:
-                        sample_refset[sample_id] = {refset_sample : [warning]}
-                    else:
-                        if refset_sample not in sample_refset[sample_id]:
-                            sample_refset[sample_id][refset_sample] = [warning]
-                        else:
-                            sample_refset[sample_id][refset_sample] += [warning]
-                
-    #for item in sample_refset:
-    #    print("jrrp", item, sample_refset[item])
+                if sample_id not in sample_refset:
+                    sample_refset[sample_id] = {refset_sample : [warning]}
+                else:
+                    print("WARNING, sample {} present twice in same run.".format(sample_id))
+                    continue
 
     return sample_refset
 
 
-def add_database_bam(bam_files, sample_refset):
-    conflicts = {"warning":{}, "present":{}, "multiple":{}}
+def add_database_bam(bam_files, sample_refset, conflicts):
     for bam in bam_files:
-        print("Processing bam {}".format(bam))
         sample_id = get_sample_id(bam)
         flowcell_id = get_flowcell_id_bam(bam)
+        refset = list(sample_refset[sample_id].keys())[0]
+        if "WARNING" in sample_refset[sample_id]:
+            refset_db = parse_refset (flowcell_id, sample_id)
+            if not refset_db:
+                conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, bam]
+        else:
+            refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
+            if not added:
+                if refset_db != refset:
+                    conflicts["present"][sample_id] = [flowcell_id, refset_db, refset, bam]
 
-        if len(sample_refset[sample_id]) == 1:  # Only one refset known for sample in  all parsed samples
-            refset = list(sample_refset[sample_id].keys())[0]
-            if "none" not in sample_refset[sample_id][refset]:  # None needs to be present, otherwise warning only sample 
-                refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset) 
-                if not added and refset_db != refset:  #Already present in db with different refset
-                    conflicts["present"][sample_id] = [flowcell_id, refset_db, refset, sample_refset[sample_id][refset]]
-            else:  # check if warning only sample is already in db
-                refset_db = parse_refset (flowcell_id, sample_id)
-                if not refset_db:
-                    conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, sample_refset[sample_id][refset]]
-        else: # multiple refset detected
-            non_warning_refsets = []
-            for refset in sample_refset[sample_id]:
-                if "none" in sample_refset[sample_id][refset]:  # Select refsets that have at least one analysis without a warning
-                    non_warning_refsets.append(refset)
-            if len(non_warning_refsets) == 1:  # Only one refset without warning, thus likely the correct one
-                refset = non_warning_refsets[0]
-                refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
-                if not added and refset_db != refset:  #Already present in db with different refset
-                    conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, sample_refset[sample_id][refset]]
-            else:
-                #conflicts = []
-                #for refset in sample_refset[sample_id]:
-                #    conflicts.append([refset , sample_refset[sample_id][refset]])  
-                #not_added["multiple"][sample_id] = [flowcell_id, "not_present", conflicts]
-                conflicts["multiple"][sample_id] = [flowcell_id, "not_present", non_warning_refsets, "none"]
-                
-    #for item in not_added:
-    #    print(item, not_added[item])
 
     return conflicts
-
-
-#def resolve_conflicts(not_added, sample_refset):
-#    unresolved = []
-#
-#    for not_add in not_added:
-#        print(not_add, sample_refset[not_add[0]])
-
-        #if conflict[3][0] == conflict conflict[4]: 
-        
-        #for item in conflict[2]:
-        #    print("jrrp",item)
-
-        #if sample_refset[conflict[0]]:
-        #    refset_list = []
-        #    for item in sample_refset[conflict[0]]:
-        #        ignore = False
-        #        for warning in item[1]:
-        #            if "DO_NOT_USE_MergeSample" in warning:
-        #                ignore = True
-
-        #else:
-        #    print("Sample {} not detected in qc_files".format(conflict[0]))
-        #    continue
-
-    #for conflict in conflicts:
-    #    if splitline[4] in qc_dic:
-    #        refset_list = []
-    #        for item in qc_dic[splitline[4]]:
-    #            ignore = False
-    #            ignore = 0
-    #            for warning in item[1]:
-    #                if "DO_NOT_USE_MergeSample" in warning:
-    #                    ignore = True
-    #                    ignore += 1
-    #            if ignore == False:
-    #                refset_list.append(item[0])
-    
-    #        if len(refset_list) == 1:  # Only 1 unique refset that is not a merge sample:  this must be the correct refset.
-    #            action = (
-    #                "source /diaggen/software/development/Dx_resources_v700/ExomeDepth/venv/bin/activate &&"
-    #                "/diaggen/software/development/Dx_resources_v700/ExomeDepth/exomedepth_db.py change_refset {} {} {} "
-    #            ).format(splitline[4], splitline[7], refset_list[0])
-    #            os.system(action)
-    #        else:  # Needs manual resolve
-    #            print("Not resolved, check manually {} {} {}".format(splitline[4], splitline[7], refset_list))
-
-    #    else: # In case sampleID is not detected in QC summary
-    #        print("Sample not detected\t{}".format(splitline[4]))
-
-
-    #return unresolved

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -159,9 +159,8 @@ def parse_refset_qc_file(qc_file):
                 splitline = line.rstrip().split(";")
                 sample_id = splitline[0]
                 warning = ""
-                header = []
-                for item in splitline:
-                    header.append(item.split("=")[0])
+                
+                header = [item.split("=")[0] for item in splitline]
                 refset_index = header.index('REFSET')
                 refset_sample = splitline[refset_index].replace("REFSET=", "")
 

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -2,6 +2,7 @@
 
 import pysam
 import glob
+import os
 
 from database.database import connect_database
 from database.models import Sample
@@ -129,8 +130,8 @@ def get_sample_id(bam):
     return sampleid
 
 
-def get_folder_sorted(path):
-    folders = sorted(set(glob.glob("{}*".format(path), recursive=True)))
+def get_folders(path):
+    folders = sorted([x[1] for x in os.walk(path)][0])
     return folders
 
 

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -131,7 +131,7 @@ def get_sample_id(bam):
 
 
 def get_folders(path):
-    folders = sorted([x[1] for x in os.walk(path)][0])
+    folders = sorted([file for file in os.listdir(path) if os.path.isdir(file)])
     return folders
 
 

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -159,7 +159,7 @@ def parse_refset_qc_file(qc_file):
                 splitline = line.rstrip().split(";")
                 sample_id = splitline[0]
                 warning = ""
-                
+
                 header = [item.split("=")[0] for item in splitline]
                 refset_index = header.index('REFSET')
                 refset_sample = splitline[refset_index].replace("REFSET=", "")

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -137,15 +137,15 @@ def get_folders(path):
 
 def get_qc_bam_files(folder):
     bam_files = []
-    qc_file = glob.glob("{}/QC/CNV/*exomedepth_summary.txt".format(folder), recursive=True)
+    qc_file = glob.glob("{}/QC/CNV/*exomedepth_summary.txt".format(folder))
     if not qc_file or len(qc_file) > 1:
         print("WARNING: CNV QC file missing of multiple detected in folder {} Skipping all samples in folder!".format(folder))
         return None, None, True
 
-    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder), recursive=True):  # Nextflow analysis
+    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder)):  # Nextflow analysis
         bam_files.append(nf_bam)
 
-    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder), recursive=True):  # IAP analysis
+    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder)):  # IAP analysis
         bam_files.append(iap_bam)
 
     return qc_file[0], bam_files, False

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -191,8 +191,7 @@ def add_database_bam(bam_files, sample_refset, conflicts):
                     refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
         else:
             refset_db, added = add_sample_flowcell_to_db(sample_id, flowcell_id, refset)
-            if not added:
-                if refset_db != refset:
-                    conflicts["present"][sample_id] = [flowcell_id, refset_db, refset, bam]
+            if not added and refset_db != refset:
+                conflicts["present"][sample_id] = [flowcell_id, refset_db, refset, bam]
 
     return conflicts

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -137,15 +137,15 @@ def get_folders(path):
 
 def get_qc_bam_files(folder):
     bam_files = []
-    qc_file = glob.glob("{}/QC/CNV/*exomedepth_summary.txt".format(folder))
+    qc_file = glob.glob(f'{folder}/QC/CNV/*exomedepth_summary.txt')
     if not qc_file or len(qc_file) > 1:
         print("WARNING: CNV QC file missing of multiple detected in folder {} Skipping all samples in folder!".format(folder))
         return None, None, True
 
-    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder)):  # Nextflow analysis
+    for nf_bam in glob.glob(f'{folder}/bam_files/*.bam'):  # Nextflow analysis
         bam_files.append(nf_bam)
 
-    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder)):  # IAP analysis
+    for iap_bam in glob.glob(f'{folder}/*/mapping/*realigned.bam'):  # IAP analysis
         bam_files.append(iap_bam)
 
     return qc_file[0], bam_files, False

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -181,7 +181,7 @@ def add_database_bam(bam_files, sample_refset, conflicts):
         sample_id = get_sample_id(bam)
         flowcell_id = get_flowcell_id_bam(bam)
         refset = list(sample_refset[sample_id].keys())[0]
-        if "WARNING" in sample_refset[sample_id]:
+        if "WARNING" in "".join(sample_refset[sample_id][refset]):
             refset_db = parse_refset(flowcell_id, sample_id)
             if not refset_db:
                 conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, bam]

--- a/ExomeDepth/database/functions.py
+++ b/ExomeDepth/database/functions.py
@@ -128,6 +128,7 @@ def get_sample_id(bam):
         sampleid = "_".join(sampleid)
     return sampleid
 
+
 def get_folder_sorted(path):
     folders = sorted(set(glob.glob("{}*".format(path), recursive=True)))
     return folders
@@ -140,10 +141,10 @@ def get_qc_bam_files(folder):
         print("WARNING: CNV QC file missing of multiple detected in folder {} Skipping all samples in folder!".format(folder))
         return None, None, True
 
-    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder), recursive=True): #  Nextflow analysis
+    for nf_bam in glob.glob("{}/bam_files/*.bam".format(folder), recursive=True):  # Nextflow analysis
         bam_files.append(nf_bam)
 
-    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder), recursive=True): # IAP analysis
+    for iap_bam in glob.glob("{}/*/mapping/*realigned.bam".format(folder), recursive=True):  # IAP analysis
         bam_files.append(iap_bam)
 
     return qc_file[0], bam_files, False
@@ -167,7 +168,7 @@ def parse_refset_qc_file(qc_file):
                     warning = ",".join(line.rstrip().split("\t")[1:])
 
                 if sample_id not in sample_refset:
-                    sample_refset[sample_id] = {refset_sample : [warning]}
+                    sample_refset[sample_id] = {refset_sample: [warning]}
                 else:
                     print("WARNING, sample {} present twice in same run.".format(sample_id))
                     continue
@@ -181,7 +182,7 @@ def add_database_bam(bam_files, sample_refset, conflicts):
         flowcell_id = get_flowcell_id_bam(bam)
         refset = list(sample_refset[sample_id].keys())[0]
         if "WARNING" in sample_refset[sample_id]:
-            refset_db = parse_refset (flowcell_id, sample_id)
+            refset_db = parse_refset(flowcell_id, sample_id)
             if not refset_db:
                 conflicts["warning"][sample_id] = [flowcell_id, refset_db, refset, bam]
         else:
@@ -189,6 +190,5 @@ def add_database_bam(bam_files, sample_refset, conflicts):
             if not added:
                 if refset_db != refset:
                     conflicts["present"][sample_id] = [flowcell_id, refset_db, refset, bam]
-
 
     return conflicts

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -97,10 +97,19 @@ def call_fill_database(args):
     qc_files, bam_files = database.functions.get_qc_bam_files(args.path)
 
     # Parse reference set for each sample from CNV QC summary file
+    print("##### started parse_refset_qc_files")
     sample_refset = database.functions.parse_refset_qc_files(qc_files)
+    print("##### finished parse_refset_qc_files")
 
     # Fill reference database for all samples (bam files) and resolve conflict
-    not_added = database.functions.add_database_bam(bam_files, sample_refset)
+    print("##### started add_database_bam")
+    conflicts = database.functions.add_database_bam(bam_files, sample_refset)
+    print("##### started add_database_bam")
+
+    for item in conflicts:
+        for sample in conflicts[item]:
+            print(conflicts[item][sample])
+            print("{}\t{}\t{}\t{}\t{}\t{}".format(item, sample, conflicts[item][sample][0], conflicts[item][sample][1], conflicts[item][sample][2], "\t".join(conflicts[item][sample][3])))
 
     # Resolve conflicts
     #unresolved = database.functions.resolve_conflicts(conflicts, sample_refset)

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -89,8 +89,6 @@ def call_delete_sample_db(args):
 def call_print_all_samples(args):
     sample_list = database.functions.return_all_samples()
     print("Name\tFlowcell\tRefset\tFamilyID")
-    for line in sample_list:
-        print(line)
 
 
 def call_fill_database(args):

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -88,7 +88,7 @@ def call_delete_sample_db(args):
 
 def call_print_all_samples(args):
     sample_list = database.functions.return_all_samples()
-    print("Name\tFlowcell\tRefset\tFamilyID")
+    print("Name\tFlowcell\tRefset")
     for line in sample_list:
         print(line)
 

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -92,9 +92,10 @@ def call_print_all_samples(args):
     for line in sample_list:
         print(line)
 
+
 def call_fill_database(args):
     folders = database.functions.get_folder_sorted(args.path)
-    conflicts = {"warning":{}, "present":{}}
+    conflicts = {"warning": {}, "present": {}}
     for folder in folders:
         qc_file, bam_files, warning = database.functions.get_qc_bam_files(folder)
         if warning:
@@ -191,7 +192,7 @@ if __name__ == "__main__":
     parser_fill_database.add_argument('path', help='path of folder to be included')
     parser_fill_database.add_argument(
         '--conflict_file',
-        default="conflicts.txt", 
+        default="conflicts.txt",
         help='output file name containing conflicts that must be resolved manually (default = conflicts.txt)'
     )
     parser_fill_database.set_defaults(func=call_fill_database)

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -92,6 +92,9 @@ def call_print_all_samples(args):
     for line in sample_list:
         print(line)
 
+def call_fill_database(args):
+    database.functions.fill_database(args.path, args.conflicts)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -166,6 +169,19 @@ if __name__ == "__main__":
     parser_delete_sample.add_argument('sample_id', help='sample id')
     parser_delete_sample.add_argument('flowcell_id', nargs='+', help='flowcell barcode')
     parser_delete_sample.set_defaults(func=call_delete_sample_db)
+
+    """ Arguments fill database based on cohort sampels"""
+    parser_fill_database = subparser.add_parser(
+        'fill_database',
+        help='Fill database based on folder path and BAM files'
+    )
+    parser_fill_database.add_argument('path', help='path of folder to be included')
+    parser_fill_database.add_argument(
+        '--conflicts',
+        default="conflicts.txt", 
+        help='output file name containing conflicts that must be resolved manually (default = conflicts.txt)'
+    )
+    parser_fill_database.set_defaults(func=call_fill_database)
 
     args = parser.parse_args()
     args.func(args)

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -93,8 +93,31 @@ def call_print_all_samples(args):
         print(line)
 
 def call_fill_database(args):
-    database.functions.fill_database(args.path, args.conflicts)
+    # Get QC and BAM files for path
+    qc_files, bam_files = database.functions.get_qc_bam_files(args.path)
 
+    # Parse reference set for each sample from CNV QC summary file
+    sample_refset = database.functions.parse_refset_qc_files(qc_files)
+
+    # Fill reference database for all samples (bam files) and resolve conflict
+    not_added = database.functions.add_database_bam(bam_files, sample_refset)
+
+    # Resolve conflicts
+    #unresolved = database.functions.resolve_conflicts(conflicts, sample_refset)
+
+
+    #for conflict in unresolved:
+    #    print(conflict)
+
+
+
+
+
+    #conflict_write_file = open (args.conflict_file, "w")
+    #for conflict in conflicts:
+    #    conflict_write_file.write(conflict)
+    #    print("jrrp", conflict)
+    #conflict_write_file.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -177,7 +200,7 @@ if __name__ == "__main__":
     )
     parser_fill_database.add_argument('path', help='path of folder to be included')
     parser_fill_database.add_argument(
-        '--conflicts',
+        '--conflict_file',
         default="conflicts.txt", 
         help='output file name containing conflicts that must be resolved manually (default = conflicts.txt)'
     )

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -94,10 +94,10 @@ def print_all_samples(args):
 
 
 def fill_database(args):
-    folders = database.functions.get_folder_sorted(args.path)
+    folders = database.functions.get_folders(args.path)
     conflicts = {"warning": {}, "present": {}}
     for folder in folders:
-        qc_file, bam_files, warning = database.functions.get_qc_bam_files(folder)
+        qc_file, bam_files, warning = database.functions.get_qc_bam_files("{}/{}".format(args.path, folder))
         if warning:
             continue
         sample_refset = database.functions.parse_refset_qc_file(qc_file)

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -89,6 +89,8 @@ def call_delete_sample_db(args):
 def call_print_all_samples(args):
     sample_list = database.functions.return_all_samples()
     print("Name\tFlowcell\tRefset\tFamilyID")
+    for line in sample_list:
+        print(line)
 
 
 def call_fill_database(args):

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -103,11 +103,10 @@ def fill_database(args):
         sample_refset = database.functions.parse_refset_qc_file(qc_file)
         conflicts = database.functions.add_database_bam(bam_files, sample_refset, conflicts)
 
-    with open(args.conflict_file, "w") as outputfile:
-        outputfile.write("Conflict\tSample\tFlowcellID\tRefsetDB\tRefsetSample\tBAM\n")
-        for conflict in conflicts:
-            for sample in conflicts[conflict]:
-                outputfile.write("{}\t{}\t{}\n".format(conflict, sample, "\t".join(conflicts[conflict][sample])))
+    args.conflict_file.write("Conflict\tSample\tFlowcellID\tRefsetDB\tRefsetSample\tBAM\n")
+    for conflict in conflicts:
+        for sample in conflicts[conflict]:
+            args.conflict_file.write("{}\t{}\t{}\n".format(conflict, sample, "\t".join(conflicts[conflict][sample])))
 
 
 if __name__ == "__main__":
@@ -193,8 +192,10 @@ if __name__ == "__main__":
     parser_fill_database.add_argument(
         '--conflict_file',
         default="conflicts.txt",
+        type=argparse.FileType('w', encoding='UTF-8'),
         help='output file name containing conflicts that must be resolved manually (default = conflicts.txt)'
     )
+
     parser_fill_database.set_defaults(func=fill_database)
 
     args = parser.parse_args()

--- a/ExomeDepth/exomedepth_db.py
+++ b/ExomeDepth/exomedepth_db.py
@@ -32,7 +32,7 @@ def print_added(flowcell_id, sample_id, refset, added):
         print_message("present_in_db", sample_id=sample_id, flowcell_id=flowcell_id, refset=refset)
 
 
-def call_add_sample_to_db(args):
+def add_sample_to_db(args):
     flowcell_id, sample_id, refset_db, added = database.functions.add_sample_to_db(
         args.flowcell_id, args.sample_id, args.refset
     )
@@ -42,7 +42,7 @@ def call_add_sample_to_db(args):
         print(refset_db)
 
 
-def call_add_sample_to_db_and_return_refset_bam(args):
+def add_sample_to_db_and_return_refset_bam(args):
     flowcell_id, sample_id, refset_db, added = database.functions.add_sample_to_db_and_return_refset_bam(
         args.bam, args.refset
     )
@@ -52,7 +52,7 @@ def call_add_sample_to_db_and_return_refset_bam(args):
         print(refset_db)
 
 
-def call_change_refset_in_db(args):
+def change_refset_in_db(args):
     flowcell_id, sample_id, refset, updated = database.functions.change_refset_in_db(
         args.flowcell_id, args.sample_id, args.refset
     )
@@ -62,7 +62,7 @@ def call_change_refset_in_db(args):
         print_message("not_detected_in_db", sample_id=sample_id, flowcell_id=flowcell_id)
 
 
-def call_query_refset(args):
+def query_refset(args):
     refset_db, flowcell_id = database.functions.query_refset(args.flowcell_id, args.sample_id)
     if refset_db:
         print(refset_db)
@@ -70,7 +70,7 @@ def call_query_refset(args):
         print_message("not_detected_in_db", sample_id=args.sample_id, flowcell_id=flowcell_id)
 
 
-def call_query_refset_bam(args):
+def query_refset_bam(args):
     refset_db, flowcell_id, sample_id = database.functions.query_refset_bam(args.bam)
     if refset_db:
         print(refset_db)
@@ -78,7 +78,7 @@ def call_query_refset_bam(args):
         print_message("not_detected_in_db", sample_id=sample_id, flowcell_id=flowcell_id)
 
 
-def call_delete_sample_db(args):
+def delete_sample_db(args):
     removed, flowcell_id = database.functions.delete_sample_db(args.flowcell_id, args.sample_id)
     if removed:
         print_message("deleted_in_db", sample_id=args.sample_id, flowcell_id=flowcell_id)
@@ -86,14 +86,14 @@ def call_delete_sample_db(args):
         print_message("not_detected_in_db", sample_id=args.sample_id, flowcell_id=flowcell_id)
 
 
-def call_print_all_samples(args):
+def print_all_samples(args):
     sample_list = database.functions.return_all_samples()
     print("Name\tFlowcell\tRefset")
     for line in sample_list:
         print(line)
 
 
-def call_fill_database(args):
+def fill_database(args):
     folders = database.functions.get_folder_sorted(args.path)
     conflicts = {"warning": {}, "present": {}}
     for folder in folders:
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     )
     parser_add.add_argument('--print_message_stdout', action='store_true', help='print message if added to db or not')
     parser_add.add_argument('--print_refset_stdout', action='store_true', help='print refset in stdout')
-    parser_add.set_defaults(func=call_add_sample_to_db)
+    parser_add.set_defaults(func=add_sample_to_db)
 
     """ Arguments add sample to database based on BAM file and return refset"""
     parser_add_return_bam = subparser.add_parser(
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         '--print_message_stdout', action='store_true', help='print message if added to db or not'
     )
     parser_add_return_bam.add_argument('--print_refset_stdout', action='store_true', help='print refset in stdout]')
-    parser_add_return_bam.set_defaults(func=call_add_sample_to_db_and_return_refset_bam)
+    parser_add_return_bam.set_defaults(func=add_sample_to_db_and_return_refset_bam)
 
     """ Arguments query refset"""
     parser_query_refset = subparser.add_parser(
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     )
     parser_query_refset.add_argument('sample_id', help='sample id')
     parser_query_refset.add_argument('flowcell_id', nargs='+', help='flowcell barcode')
-    parser_query_refset.set_defaults(func=call_query_refset)
+    parser_query_refset.set_defaults(func=query_refset)
 
     """ Arguments query refset based on BAM file"""
     parser_query_refset_bam = subparser.add_parser(
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         help='return refset of sample based on BAM file'
     )
     parser_query_refset_bam.add_argument('bam', help='full path to BAM file')
-    parser_query_refset_bam.set_defaults(func=call_query_refset_bam)
+    parser_query_refset_bam.set_defaults(func=query_refset_bam)
 
     """ Arguments change refset in database for sample"""
     parser_change = subparser.add_parser(
@@ -166,14 +166,14 @@ if __name__ == "__main__":
     parser_change.add_argument('sample_id', help='sample id')
     parser_change.add_argument('flowcell_id', help='flowcell barcode (as in database)')
     parser_change.add_argument('refset', help='new refset ID')
-    parser_change.set_defaults(func=call_change_refset_in_db)
+    parser_change.set_defaults(func=change_refset_in_db)
 
     """ Arguments to print all entries of database """
     parser_allsamples = subparser.add_parser(
         'print_all_samples',
         help='Print full database table (tab-separated)'
     )
-    parser_allsamples.set_defaults(func=call_print_all_samples)
+    parser_allsamples.set_defaults(func=print_all_samples)
 
     """ Arguments delete sample in database"""
     parser_delete_sample = subparser.add_parser(
@@ -182,7 +182,7 @@ if __name__ == "__main__":
     )
     parser_delete_sample.add_argument('sample_id', help='sample id')
     parser_delete_sample.add_argument('flowcell_id', nargs='+', help='flowcell barcode')
-    parser_delete_sample.set_defaults(func=call_delete_sample_db)
+    parser_delete_sample.set_defaults(func=delete_sample_db)
 
     """ Arguments fill database based on cohort sampels"""
     parser_fill_database = subparser.add_parser(
@@ -195,7 +195,7 @@ if __name__ == "__main__":
         default="conflicts.txt",
         help='output file name containing conflicts that must be resolved manually (default = conflicts.txt)'
     )
-    parser_fill_database.set_defaults(func=call_fill_database)
+    parser_fill_database.set_defaults(func=fill_database)
 
     args = parser.parse_args()
     args.func(args)

--- a/ExomeDepth/settings.py
+++ b/ExomeDepth/settings.py
@@ -54,8 +54,8 @@ probability = {"HC": 0.0001, "UMCU": 0.5}
 
 # General settings
 ratio_threshold_del = 0.25
-par1 = [60001,2699520]
-par2 = [154931044,155260560]
+par1 = [60001, 2699520]
+par2 = [154931044, 155260560]
 locus_y = 'Y:2649520-59034050'
 locus_x = 'X:2699520-154931044'
 ratio_y = [0.02, 0.12]


### PR DESCRIPTION
Feature to fill the referenceset database based on sequence runs/projects.

* First step is to identify sequence project, and order based on data. This is important as the first sequence run of a project is regarded as the original one (if without merge warnings).
* Second step is to retrieve Refset as described in QC-CNV summary files (archive folders are skipped). If no QC-CNV file is detected in the (project)folder, the entire folder is skipped.
*  Samples without merge-warning will be added to de database. If already present in de database, but with a different refset this sample will be reported as conflict.
* Samples that are only present with a merge warning (such as rescue samples) will not be added, and also reported as conflict.
* conflicts need to be manually resolved. 