### PR TITLE
Feature/child parent clarity

### DIFF
--- a/ExomeDepth/make_BEDdetail.py
+++ b/ExomeDepth/make_BEDdetail.py
@@ -37,6 +37,7 @@ def get_familystatus_clarity(sampleid):
     else:
         return "unknown"
 
+
 def get_familystatus_sampleid(sampleid):
     if any([child_tag in sampleid for child_tag in ['CM', 'CF', 'CO']]):
         return "child"
@@ -63,7 +64,7 @@ def slice_vcf(args, merge_dic):
         )
 
         event_dic = {}
-        count_familystatus = {"child":0, "parent": 0}
+        count_familystatus = {"child": 0, "parent": 0}
 
         if not args.random_off:
             random.shuffle(vcf_files)
@@ -127,8 +128,8 @@ def slice_vcf(args, merge_dic):
                             sampleid=sampleid,
                             runid=runid
                         )
-                    ) 
-               
+                    )
+
                 count_familystatus[sampletype] += 1
 
                 if 'gender_refset' in vcf_reader.metadata:

--- a/ExomeDepth/make_BEDdetail.py
+++ b/ExomeDepth/make_BEDdetail.py
@@ -26,7 +26,7 @@ def make_merge_dic(merge_samples):
 
 
 def get_familystatus_clarity(sampleid):
-    """Get sample gender from Clarity LIMS."""
+    """Get family status from Clarity LIMS."""
     lims_client = Lims(settings.clarity_baseuri, settings.clarity_username, settings.clarity_password)
     samples = lims_client.get_samples(udf={settings.monster_udf: sampleid})
     familystatus = []
@@ -129,6 +129,7 @@ def slice_vcf(args, merge_dic):
                             runid=runid
                         )
                     )
+                    continue
 
                 count_familystatus[sampletype] += 1
 

--- a/ExomeDepth/settings.py
+++ b/ExomeDepth/settings.py
@@ -81,7 +81,9 @@ force_gender = "male"
 # Clarity settings
 monster_udf = "Dx Monsternummer"
 geslacht_udf = "Dx Geslacht"
+familie_udf = "Dx Familie status"
 gender_translation = {"vrouw": "female", "man": "male", "onbekend": "unknown"}
+family_translation = {"kind": "child", "ouder": "parent"}
 
 # IGV session settings:
 template_single_xml = str(cwd)+"/templates/igv_session_template_single.xml"

--- a/ExomeDepth/tests/test_make_BEDdetail.py
+++ b/ExomeDepth/tests/test_make_BEDdetail.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import pytest
+
+from make_BEDdetail import get_familystatus_sampleid
+
+
+@pytest.mark.parametrize("sample_id, expected", [
+    ("U175754CM2022D12878", "child"),
+    ("U175754CF2022D12878", "child"),
+    ("U175754CO2022D12878", "child"),
+    ("U175754PM2022D12878", "parent"),
+    ("U175754PF2022D12878", "parent"),
+    ("U175754PO2022D12878", "parent"),
+    ("U175754CC2022D12878", "unknown"),
+    ("2022D12878", "unknown"),
+])
+def test_familystatus_sampleid(sample_id, expected):
+    sample_id = get_familystatus_sampleid(sample_id)
+    assert sample_id == expected


### PR DESCRIPTION
* added fallback Clarity db to determine family status (child or parent) instead of metadata in sampleID